### PR TITLE
Fix CLI building/build caches w/ preview tooling for libs

### DIFF
--- a/EasyXAMLTools/EasyXAMLTools.csproj
+++ b/EasyXAMLTools/EasyXAMLTools.csproj
@@ -5,6 +5,8 @@
 		<RootNamespace>EasyXAMLTools</RootNamespace>
 		<RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 		<UseWinUI>true</UseWinUI>
+		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/EasyXAMLToolsTest/EasyXAMLToolsTest.csproj
+++ b/EasyXAMLToolsTest/EasyXAMLToolsTest.csproj
@@ -10,6 +10,8 @@
 		<PublishProfile>win10-$(Platform).pubxml</PublishProfile>
 		<UseWinUI>true</UseWinUI>
 		<EnableMsixTooling>true</EnableMsixTooling>
+		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fix CLI building/build caches w/ preview tooling for libs
WinUI dotnet cli building for libs is a bit broken ( dotnet/maui#5886 ) this fixes that. This also fixes the issue that some of the xaml libs (ie cubeui) were rebuilding on every build even if not modified. Cuts my build time by about half.